### PR TITLE
chore: setup utils and core packages with entry points

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,5 @@
+import { externalAsync, ReturnType } from "@halvaradop/repo-utils"
+
+type ExternalAsyncType = ReturnType<typeof externalAsync>
+
+console.log("ExternalAsyncRequest", "ExternalType", "FixExternalFunction")

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@halvaradop/repo-utils",
   "version": "1.0.0",
+  "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "dev": "tsc -w",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "config": "tsc --showConfig"
   },
   "keywords": [],
   "author": "",
@@ -18,5 +20,13 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.d.ts",
+      "default": "./dist/utils.js"
+    },
+    "./utils/*": "./dist/**.js"
+  }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,2 @@
+export type { ArgsMethod, ArgsAsyncMethod, ReturnType } from "./types"
+export { externalAsync } from "./utils"

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,0 +1,3 @@
+export type ArgsMethod = (...args: any) => void
+export type ArgsAsyncMethod = Promise<ArgsMethod>
+export type ReturnType<T extends ArgsMethod> = T extends (...args: any) => infer Return ? Return : never

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,0 +1,3 @@
+export const externalAsync = async () => {
+    // fetching data
+}


### PR DESCRIPTION
# Description
This pull request introduces key changes to set up the `utils` and `core` packages within the monorepo project, establishing a solid foundation for configuration, testing, and development using technologies like JavaScript, TypeScript, Node.js, and npm.

The primary goal of this pull request is to verify that the configuration established in the `utils` package functions correctly when the package is published and consumed by another project (in this case, the `core` package). Given the complexity of setting up configurations that seamlessly work with both JavaScript and TypeScript, this setup aims to address challenges such as correctly importing types and functions to avoid errors from incorrect file references.

## Key changes
- Set up the `utils` and core packages within the project repository.
- Created and defined types, functions, and properties in the `utils` package, and organized their exports in index.js.
- Properly configured the `utils/package.json` to include an exports property for controlling access to package contents.
- Defined two entry points in the package using export property
	- An entry point for all `.d.ts` files.
	- An entry point named utils for the `.js` files.
- Released the initial version of `halvaradop/repo-utils`, which will be used to test the integration and functionality of the package when consumed by the `core` package.